### PR TITLE
Add DumpIndex util to easily print index info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             </program>
             <program>
               <mainClass>io.anserini.util.DumpIndex</mainClass>
-              <name>dumpindex</name>
+              <name>DumpIndex</name>
             </program>
             <program>
               <mainClass>io.anserini.util.DumpDocids</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
               <name>TweetSearcher</name>
             </program>
             <program>
+              <mainClass>io.anserini.util.DumpIndex</mainClass>
+              <name>dumpindex</name>
+            </program>
+            <program>
               <mainClass>io.anserini.util.DumpDocids</mainClass>
               <name>DumpDocids</name>
             </program>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
               <name>TweetSearcher</name>
             </program>
             <program>
-              <mainClass>io.anserini.util.DumpIndex</mainClass>
+              <mainClass>io.anserini.dumpindex.DumpIndex</mainClass>
               <name>DumpIndex</name>
             </program>
             <program>

--- a/src/main/java/io/anserini/dumpindex/DumpIndexArgs.java
+++ b/src/main/java/io/anserini/dumpindex/DumpIndexArgs.java
@@ -1,0 +1,54 @@
+package io.anserini.dumpindex;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.BooleanOptionHandler;
+import org.kohsuke.args4j.spi.IntOptionHandler;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+import java.util.List;
+
+/**
+ * Common arguments (dataDir, indexPath, numThreads, etc) necessary for indexing.
+ */
+public class DumpIndexArgs {
+
+  // required arguments
+
+  @Option(name = "-index", metaVar = "[Path]", required = true, usage = "Lucene index path")
+  String index;
+
+  @Option(name = "-s", forbids = {"-t","-di","-dn","-dt","-dv"}, handler=BooleanOptionHandler.class, usage = "Print statistics for the Repository")
+  boolean stats;
+
+  @Option(name = "-t", forbids = {"-s","-di","-dn","-dt","-dv"}, usage = "Print term info: stemmed, total counts, doc counts")
+  String term;
+
+  @Option(name = "-di", forbids = {"-s","-t","-dn","-dt","-dv"}, handler = StringArrayOptionHandler.class, usage = "Print the internal document IDs of documents")
+  List<String> di;
+
+  @Option(name = "-dn", forbids = {"-s","-t","-di","-dt","-dv"}, handler = IntOptionHandler.class, usage = "Print the text representation of a document ID")
+  int dn;
+
+  @Option(name = "-dt", forbids = {"-s","-t","-di","-dn","-dv"}, handler = IntOptionHandler.class, usage = "Print the text of a document")
+  int dt;
+
+  @Option(name = "-dv", forbids = {"-s","-t","-di","-dt","-dn"}, handler = IntOptionHandler.class, usage = "Print the document vector of a document")
+  int dv;
+}

--- a/src/main/java/io/anserini/dumpindex/README.md
+++ b/src/main/java/io/anserini/dumpindex/README.md
@@ -1,0 +1,32 @@
+DumpIndex provides an easy way to print various information of the index via CLI
+
+```-index```
+
+The path of the index
+
+```-s```
+
+Print statistics for the Repository: total docs count, total terms count, etc.
+
+```-t```
+
+Print term info: stemmed, total counts, doc counts
+
+```-di```
+
+Print the internal document IDs of documents
+
+```-dn```
+
+Print the text representation of a document ID
+The document ID is the internal document ID starting from 1
+
+```-dt```
+
+Print the text of a document (only if the raw documents are stored)
+The document ID is the internal document ID starting from 1
+
+```-dv```
+
+Print the document vector of a document (only if the document vectors are stored)
+The document ID is the internal document ID starting from 1

--- a/src/main/java/io/anserini/util/DumpIndex.java
+++ b/src/main/java/io/anserini/util/DumpIndex.java
@@ -1,0 +1,70 @@
+package io.anserini.util;
+
+import io.anserini.index.IndexWebCollection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DumpIndex {
+  private static final Logger LOG = LogManager.getLogger(DumpIndex.class);
+
+  String print_repository_stats( String indexDir ) throws IOException {
+    FSDirectory dir = FSDirectory.open(new File(indexDir).toPath());
+    DirectoryReader reader = DirectoryReader.open(dir);
+
+    int docCount = reader.numDocs();
+    int contentsCount = reader.getDocCount(IndexWebCollection.FIELD_BODY);
+    long termCount = reader.getSumTotalTermFreq(IndexWebCollection.FIELD_BODY);
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("Repository statistics:\n");
+    sb.append("documents:\t" + docCount + "\n");
+    sb.append("contentsCount(doc with contents):\t" + contentsCount + "\n");
+    //sb.append("unique terms:\t" + uniqueTermCount);
+    sb.append("total terms:\t" + termCount + "\n");
+    sb.append("fields:\t\t" + IndexWebCollection.FIELD_ID + " " + IndexWebCollection.FIELD_BODY);
+    sb.append("\n");
+
+    return sb.toString();
+  }
+
+  boolean argsEnough(int n, int required) {
+    if (n < required) {
+      printUsage();
+      return false;
+    }
+    return true;
+  }
+
+  void printUsage() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("DumpIndex <repository> <command> [ <argument> ]*\n")
+      .append("These commands retrieve data from the repository: \n")
+      .append("    Command              Argument       Description\n")
+      .append("    stats (s)                           Print statistics for the Repository\n");
+    System.out.println(sb.toString());
+  }
+
+  public static void main(String[] clArgs) throws IOException{
+    int argc = clArgs.length;
+    final DumpIndex ic = new DumpIndex();
+    try {
+      String indexPath = clArgs[0];
+      String command = clArgs[1];
+      try {
+        if (command.equals("s") || command.equals("stats")) {
+          ic.argsEnough(2, argc);
+          System.out.println(ic.print_repository_stats(indexPath));
+        }
+      } catch (Exception e) {
+        LOG.error(e.getMessage());
+      }
+    } catch (IndexOutOfBoundsException e) {
+      ic.printUsage();
+    }
+  }
+}

--- a/src/main/java/io/anserini/util/DumpIndex.java
+++ b/src/main/java/io/anserini/util/DumpIndex.java
@@ -3,19 +3,34 @@ package io.anserini.util;
 import io.anserini.index.IndexWebCollection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.*;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.FSDirectory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 public class DumpIndex {
   private static final Logger LOG = LogManager.getLogger(DumpIndex.class);
 
-  String print_repository_stats( String indexDir ) throws IOException {
-    FSDirectory dir = FSDirectory.open(new File(indexDir).toPath());
-    DirectoryReader reader = DirectoryReader.open(dir);
+  class RawDocNotStoredException extends Exception {
+    public RawDocNotStoredException(String message) {
+      super(message);
+    }
+  }
+  class DocVectorNotStoredException extends Exception {
+    public DocVectorNotStoredException(String message) {
+      super(message);
+    }
+  }
 
+  String print_repository_stats( DirectoryReader reader ) throws IOException {
     int docCount = reader.numDocs();
     int contentsCount = reader.getDocCount(IndexWebCollection.FIELD_BODY);
     long termCount = reader.getSumTotalTermFreq(IndexWebCollection.FIELD_BODY);
@@ -26,9 +41,84 @@ public class DumpIndex {
     sb.append("contentsCount(doc with contents):\t" + contentsCount + "\n");
     //sb.append("unique terms:\t" + uniqueTermCount);
     sb.append("total terms:\t" + termCount + "\n");
-    sb.append("fields:\t\t" + IndexWebCollection.FIELD_ID + " " + IndexWebCollection.FIELD_BODY);
-    sb.append("\n");
+    sb.append("stored fields:\t\t");
 
+    Document d = reader.document(1);
+    List<IndexableField> fields = d.getFields();
+    for (IndexableField f : fields) {
+      sb.append(f.name()+" ");
+    }
+    sb.append("\n");
+    return sb.toString();
+  }
+
+  String print_term_counts( DirectoryReader reader, String termStr )
+          throws IOException, ParseException {
+    StringBuilder sb = new StringBuilder();
+    EnglishAnalyzer ea = new EnglishAnalyzer(CharArraySet.EMPTY_SET);
+    QueryParser qp = new QueryParser(IndexWebCollection.FIELD_BODY, ea);
+    TermQuery q = (TermQuery)qp.parse(termStr);
+    long termFreq = reader.totalTermFreq(q.getTerm());
+    long docCount = reader.docFreq(q.getTerm());
+    sb.append(termStr+" ")
+      .append(q.toString(IndexWebCollection.FIELD_BODY)+" ")
+      .append(termFreq+" ")
+      .append(docCount+" ")
+      .append("\n");
+    return sb.toString();
+  }
+
+  /*
+  * print the internal id
+  */
+  String print_document_id( DirectoryReader reader, String externalId ) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 1; i < reader.maxDoc()+1; i++) {
+      Document d = reader.document(i);
+      IndexableField id = d.getField(IndexWebCollection.FIELD_ID);
+      if (externalId.equals(id.stringValue())) {
+        sb.append(i);
+        break;
+      }
+    }
+    sb.append("\n");
+    return sb.toString();
+  }
+
+  String print_document_name( DirectoryReader reader, int number ) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    Document d = reader.document(number);
+    IndexableField id = d.getField(IndexWebCollection.FIELD_ID);
+    sb.append(id.stringValue())
+      .append("\n");
+    return sb.toString();
+  }
+
+  String print_document_text( DirectoryReader reader, int number ) throws IOException, RawDocNotStoredException {
+    StringBuilder sb = new StringBuilder();
+    Document d = reader.document(number);
+    IndexableField id = d.getField(IndexWebCollection.FIELD_BODY);
+    if (id == null) {
+      throw new RawDocNotStoredException("Raw Contents not Stored!");
+    }
+    sb.append(id.stringValue())
+      .append("\n");
+    return sb.toString();
+  }
+
+  String print_document_vector( DirectoryReader reader, int number ) throws IOException, DocVectorNotStoredException {
+    StringBuilder sb = new StringBuilder();
+    Terms terms = reader.getTermVector(number, IndexWebCollection.FIELD_BODY);
+    if (terms == null) {
+      throw new DocVectorNotStoredException("Doc Vector not Stored!");
+    }
+    TermsEnum te = terms.iterator();
+    if (te == null) {
+      throw new DocVectorNotStoredException("Doc Vector not Stored!");
+    }
+    while((te.next()) != null){
+      sb.append(te.term().utf8ToString()+" "+te.totalTermFreq()+"\n");
+    }
     return sb.toString();
   }
 
@@ -45,6 +135,12 @@ public class DumpIndex {
     sb.append("DumpIndex <repository> <command> [ <argument> ]*\n")
       .append("These commands retrieve data from the repository: \n")
       .append("    Command              Argument       Description\n")
+      .append("    term (t)             Term text      Print inverted list for a term\n")
+      .append("    dxcount (dx)         Expression     Print document count of occurrences of an Indri expression\n")
+      .append("    documentid (di)      Field, Value   Print the document IDs of documents having a metadata field matching this value\n")
+      .append("    documentname (dn)    Document ID    Print the text representation of a document ID\n")
+      .append("    documenttext (dt)    Document ID    Print the text of a document\n")
+      .append("    documentvector (dv)  Document ID    Print the document vector of a document\n")
       .append("    stats (s)                           Print statistics for the Repository\n");
     System.out.println(sb.toString());
   }
@@ -55,11 +151,37 @@ public class DumpIndex {
     try {
       String indexPath = clArgs[0];
       String command = clArgs[1];
+
+      FSDirectory dir = FSDirectory.open(new File(indexPath).toPath());
+      DirectoryReader reader = DirectoryReader.open(dir);
+
+      String dump = null;
       try {
         if (command.equals("s") || command.equals("stats")) {
           ic.argsEnough(2, argc);
-          System.out.println(ic.print_repository_stats(indexPath));
+          dump = ic.print_repository_stats(reader);
+        } else if (command.equals("t") || command.equals("term")) {
+          ic.argsEnough(3, argc);
+          String termString = clArgs[2];
+          dump = ic.print_term_counts(reader, termString);
+        } else if (command.equals("di") || command.equals("documentid")) {
+          ic.argsEnough(3, argc);
+          String externalId = clArgs[2];
+          dump = ic.print_document_id(reader, externalId);
+        } else if (command.equals("dn") || command.equals("documentname")) {
+          ic.argsEnough(3, argc);
+          int number = Integer.parseInt(clArgs[2]);
+          dump = ic.print_document_name(reader, number);
+        } else if (command.equals("dt") || command.equals("documenttext")) {
+          ic.argsEnough(3, argc);
+          int number = Integer.parseInt(clArgs[2]);
+          dump = ic.print_document_text(reader, number);
+        } else if (command.equals("dv") || command.equals("documentvector")) {
+          ic.argsEnough(3, argc);
+          int number = Integer.parseInt(clArgs[2]);
+          dump = ic.print_document_vector(reader, number);
         }
+        System.out.println(dump);
       } catch (Exception e) {
         LOG.error(e.getMessage());
       }

--- a/src/main/java/io/anserini/util/DumpIndex.java
+++ b/src/main/java/io/anserini/util/DumpIndex.java
@@ -1,5 +1,22 @@
 package io.anserini.util;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import io.anserini.index.IndexWebCollection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
The purpose:

1. Let the user print the index info more easily. This could be used if the user wants to see the stats of the index in order to confirm the correctness of indexing process, e.g. number of docs in the index.
2. Indri has dumpindex util which is convenient. People would be more willing to migrate to Anserini if we have the same util.

The stats include:

- index stats
- term counts
- document dump (find id, find name, print text, print vector)


