### PR TITLE
add support for indexing trectext collections (disk1-5 + AQUAINT)

### DIFF
--- a/src/main/java/io/anserini/document/Collection.java
+++ b/src/main/java/io/anserini/document/Collection.java
@@ -4,5 +4,5 @@ package io.anserini.document;
  * Information Retrieval Collections
  */
 public enum Collection {
-  CW09, CW12, GOV2, Twitter
+  CW09, CW12, GOV2, Twitter, TrecText
 }

--- a/src/main/java/io/anserini/document/TrecTextRecord.java
+++ b/src/main/java/io/anserini/document/TrecTextRecord.java
@@ -1,0 +1,74 @@
+package io.anserini.document;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.anserini.index.IndexWebCollection;
+
+public final class TrecTextRecord {
+
+  public static final String DOCNO = "<DOCNO>";
+  public static final String TERMINATING_DOCNO = "</DOCNO>";
+
+  public static final String DOC = "<DOC>";
+  public static final String TERMINATING_DOC = "</DOC>";
+
+  public static final String[] startTags = {"<TEXT>", "<HEADLINE>", "<TITLE>", "<HL>", "<HEAD>",
+          "<TTL>", "<DD>", "<DATE>", "<LP>", "<LEADPARA>"
+  };
+  public static final String[] endTags = {"</TEXT>", "</HEADLINE>", "</TITLE>", "</HL>", "</HEAD>",
+          "</TTL>", "</DD>", "</DATE>", "</LP>", "</LEADPARA>"
+  };
+
+  public static final int BUFFER_SIZE = 1 << 16; // 64K
+
+  public static WarcRecord parseTrecTextRecord(StringBuilder builder) {
+    int i = builder.indexOf(DOCNO);
+    if (i == -1) throw new RuntimeException("cannot find start tag " + DOCNO);
+
+    if (i != 0) throw new RuntimeException("should start with " + DOCNO);
+
+    int j = builder.indexOf(TERMINATING_DOCNO);
+    if (j == -1) throw new RuntimeException("cannot find end tag " + TERMINATING_DOCNO);
+
+    final String docID = builder.substring(i + DOCNO.length(), j).trim();
+
+    final String content = builder.substring(j + TERMINATING_DOCNO.length()).trim();
+
+    return new WarcRecord() {
+      @Override
+      public String id() {
+        return docID;
+      }
+
+      @Override
+      public String content() {
+        return content;
+      }
+
+      @Override
+      public String url() {
+        return null;
+      }
+
+      @Override
+      public String type() {
+        return IndexWebCollection.RESPONSE;
+      }
+    };
+  }
+}

--- a/src/main/java/io/anserini/index/IndexWebCollection.java
+++ b/src/main/java/io/anserini/index/IndexWebCollection.java
@@ -210,10 +210,10 @@ public final class IndexWebCollection {
         BufferedInputStream in = new BufferedInputStream(fin);
         ZCompressorInputStream zIn = new ZCompressorInputStream(in);
         reader = new BufferedReader(new InputStreamReader(zIn, StandardCharsets.UTF_8));
-      } else if (fileName.endsWith(".gz")) {
+      } else if (fileName.endsWith(".gz")) { //.gz
         InputStream stream = new GZIPInputStream(Files.newInputStream(inputWarcFile, StandardOpenOption.READ), TrecTextRecord.BUFFER_SIZE);
         reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-      } else {
+      } else { // plain text file
         reader = new BufferedReader(new FileReader(fileName));
       }
 
@@ -396,7 +396,7 @@ public final class IndexWebCollection {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
         Path name = file.getFileName();
-        if (name != null && !name.startsWith("readme")) {
+        if (name != null && !name.toString().startsWith("readme")) {
           stack.add(file);
         }
         return FileVisitResult.CONTINUE;

--- a/src/main/java/io/anserini/index/IndexWebCollection.java
+++ b/src/main/java/io/anserini/index/IndexWebCollection.java
@@ -205,7 +205,7 @@ public final class IndexWebCollection {
 
       BufferedReader reader = null;
       String fileName = inputWarcFile.toString();
-      if (fileName.endsWith(".z")) {
+      if (fileName.matches(".*?\\.\\d*z$")) { // .z .0z .1z .2z
         FileInputStream fin = new FileInputStream(fileName);
         BufferedInputStream in = new BufferedInputStream(fin);
         ZCompressorInputStream zIn = new ZCompressorInputStream(in);

--- a/src/main/java/io/anserini/index/IndexWebCollection.java
+++ b/src/main/java/io/anserini/index/IndexWebCollection.java
@@ -210,6 +210,9 @@ public final class IndexWebCollection {
         BufferedInputStream in = new BufferedInputStream(fin);
         ZCompressorInputStream zIn = new ZCompressorInputStream(in);
         reader = new BufferedReader(new InputStreamReader(zIn, StandardCharsets.UTF_8));
+      } else if (fileName.endsWith(".gz")) {
+        InputStream stream = new GZIPInputStream(Files.newInputStream(inputWarcFile, StandardOpenOption.READ), TrecTextRecord.BUFFER_SIZE);
+        reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
       } else {
         reader = new BufferedReader(new FileReader(fileName));
       }

--- a/src/main/java/io/anserini/index/IndexWebCollection.java
+++ b/src/main/java/io/anserini/index/IndexWebCollection.java
@@ -18,15 +18,16 @@ package io.anserini.index;
  */
 
 import io.anserini.document.*;
+import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexWriter;
@@ -45,7 +46,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -194,6 +197,78 @@ public final class IndexWebCollection {
       return i;
     }
 
+    private int indexTrecTextFile() throws IOException {
+      int i = 0;
+      StringBuilder builder = new StringBuilder();
+      boolean found = false;
+      int inTag = -1;
+
+      BufferedReader reader = null;
+      String fileName = inputWarcFile.toString();
+      if (fileName.endsWith(".z")) {
+        FileInputStream fin = new FileInputStream(fileName);
+        BufferedInputStream in = new BufferedInputStream(fin);
+        ZCompressorInputStream zIn = new ZCompressorInputStream(in);
+        reader = new BufferedReader(new InputStreamReader(zIn, StandardCharsets.UTF_8));
+      } else {
+        reader = new BufferedReader(new FileReader(fileName));
+      }
+
+      for (; ; ) {
+        String line = reader.readLine();
+        if (line == null)
+          break;
+
+        line = line.trim();
+
+        if (line.startsWith(TrecTextRecord.DOC)) {
+          found = true;
+          // continue to read DOCNO
+          while ((line = reader.readLine()) != null) {
+            if (line.startsWith(TrecTextRecord.DOCNO)) {
+              builder.append(line).append('\n');
+              break;
+            }
+          }
+          while (builder.indexOf(TrecTextRecord.TERMINATING_DOCNO) == -1) {
+            line = reader.readLine();
+            if (line == null) break;
+            builder.append(line).append('\n');
+          }
+          continue;
+        }
+
+        if (line.startsWith(TrecTextRecord.TERMINATING_DOC)) {
+          found = false;
+          WarcRecord trecText = TrecTextRecord.parseTrecTextRecord(builder);
+          i += indexWarcRecord(trecText);
+          builder.setLength(0);
+        }
+
+        if (found) {
+          if (line.startsWith("<")) {
+            if (inTag >= 0 && line.startsWith(TrecTextRecord.endTags[inTag])) {
+              builder.append(line).append("\n");
+              inTag = -1;
+            } else if (inTag < 0) {
+              for (int k = 0; k < TrecTextRecord.startTags.length; k++) {
+                if (line.startsWith(TrecTextRecord.startTags[k])) {
+                  inTag = k;
+                  break;
+                }
+              }
+            }
+          }
+          if (inTag >= 0) {
+            builder.append(line).append("\n");
+          }
+        }
+      }
+
+
+      return i;
+    }
+
     @Override
     public void run() {
       {
@@ -206,6 +281,9 @@ public final class IndexWebCollection {
             System.out.println("./" + inputWarcFile.getParent().getFileName().toString() + File.separator + inputWarcFile.getFileName().toString() + "\t" + addCount);
           } else if (Collection.GOV2.equals(collection)) {
             int addCount = indexGov2File();
+            System.out.println("./" + inputWarcFile.getParent().getFileName().toString() + File.separator + inputWarcFile.getFileName().toString() + "\t" + addCount);
+          } else if (Collection.TrecText.equals(collection)) {
+            int addCount = indexTrecTextFile();
             System.out.println("./" + inputWarcFile.getParent().getFileName().toString() + File.separator + inputWarcFile.getFileName().toString() + "\t" + addCount);
           }
 
@@ -306,6 +384,45 @@ public final class IndexWebCollection {
     return stack;
   }
 
+  static Deque<Path> discoverTrecTextFiles(Path p) {
+
+    final Deque<Path> stack = new ArrayDeque<>();
+
+    FileVisitor<Path> fv = new SimpleFileVisitor<Path>() {
+
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Path name = file.getFileName();
+        if (name != null && !name.startsWith("readme")) {
+          stack.add(file);
+        }
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+        HashSet<String> disallowedDirs = new HashSet<>(Arrays.asList("cr", "dtd", "dtds"));
+        if (disallowedDirs.contains(dir.getFileName().toString())) {
+          LOG.info("Skipping: " + dir);
+          return FileVisitResult.SKIP_SUBTREE;
+        }
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult visitFileFailed(Path file, IOException ioe) {
+        LOG.error("Visiting failed for " + file.toString(), ioe);
+        return FileVisitResult.SKIP_SUBTREE;
+      }
+    };
+
+    try {
+      Files.walkFileTree(p, fv);
+    } catch (IOException e) {
+      LOG.error("IOException during file visiting", e);
+    }
+    return stack;
+  }
 
   public int indexWithThreads(int numThreads) throws IOException, InterruptedException {
 
@@ -325,8 +442,9 @@ public final class IndexWebCollection {
     final IndexWriter writer = new IndexWriter(dir, iwc);
 
     final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(numThreads);
-    final String suffix = Collection.GOV2.equals(collection) ? ".gz" : ".warc.gz";
-    final Deque<Path> warcFiles = discoverWarcFiles(docDir, suffix);
+    final String suffix = Collection.GOV2.equals(collection) ? ".gz" : Collection.TrecText.equals(collection) ? "" : ".warc.gz";
+    final Deque<Path> warcFiles = Collection.TrecText.equals(collection) ? discoverTrecTextFiles(docDir)
+            : discoverWarcFiles(docDir, suffix);
 
     if (doclimit > 0 && warcFiles.size() < doclimit)
       for (int i = doclimit; i < warcFiles.size(); i++)


### PR DESCRIPTION
@lintool 
The code is mixed with IndexWebCollection. I think we'd better separate them some time in the future. 
Tested with disk1-5 and AQUAINT
**NOTE**: For AQUAINT, we only have the uncompressed version. I think the original files are gzipped? In the code I have this support, can you try that? 

Index Stats:

- DISK12

documents:      741687
contentsCount(doc with contents):       741686
total terms (with or without stop word):    311265071 / 222530202

- DISK45 (the CR dir is ignored in the code)

documents:      528030
contentsCount(doc with contents):       528030
total terms (with or without stop word):    251357430 / 174540587

- AQUAINT

documents:      1031455
contentsCount(doc with contents):       1031326
total terms (with or without stop word):    446995583 / 320157232


