### PR TITLE
add Eval module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
               <name>SearchWebCollection</name>
             </program>
             <program>
+              <mainClass>io.anserini.eval.Eval</mainClass>
+              <name>Eval</name>
+            </program>
+            <program>
               <mainClass>io.anserini.SearchTimeUtil</mainClass>
               <name>Time</name>
             </program>

--- a/src/main/java/io/anserini/eval/BatchEval.java
+++ b/src/main/java/io/anserini/eval/BatchEval.java
@@ -1,0 +1,87 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval;
+
+import io.anserini.eval.metric.MetricBase;
+import io.anserini.eval.metric.MetricFactory;
+
+import java.util.*;
+
+/**
+ * The abstract class for all batch eval.
+ * batch eval applies to a set of queries
+ */
+public class BatchEval {
+  protected String metricName;
+  protected MetricBase metricBase;
+  protected Map<String, Double> evals;
+  protected double aggregated;
+
+  public BatchEval(String metricName) {
+    this.metricName = metricName;
+    metricBase = MetricFactory.instance(metricName);
+    evals = new TreeMap<>();
+  }
+
+  public String getMetricName() {
+    return metricName;
+  }
+
+  public MetricBase getMetricBase() {
+    return metricBase;
+  }
+
+  public Map<String, Double> getEvals() {
+    return evals;
+  }
+
+  public double getAggregated() {
+    return aggregated;
+  }
+
+  /*
+      *
+      * evaluate a bunch of queries
+      */
+  public Map<String, Double> evaluate(Map<String, List<ResultDoc>> resultLists, Map<String, Map<String, Integer>> judgments) {
+    evals.clear();
+    for (String query : resultLists.keySet()) {
+      List<ResultDoc> qResList = resultLists.get(query);
+      Map<String, Integer> qJudge = judgments.get(query);
+      if (qResList != null && qJudge != null) {
+        double score = metricBase.evaluate(qResList, qJudge);
+        evals.put(query, score);
+      }
+    }
+
+    if (metricName.equals("num_ret") || metricName.equals("num_rel") || metricName.equals("num_rel_ret")) {
+      aggregated = evals.values().stream().mapToDouble(a->a).sum();
+    } else {
+      aggregated = evals.values().stream().mapToDouble(a->a).average().getAsDouble();
+    }
+
+    return evals;
+  }
+
+  public Map<String, Double> evaluate(RankingResults resultLists, QueryJudgments judgments) {
+    return evaluate(resultLists.getRankingList(), judgments.getQrels());
+  }
+
+  public String getFormat() {
+    return metricBase.getFormat();
+  }
+}

--- a/src/main/java/io/anserini/eval/Eval.java
+++ b/src/main/java/io/anserini/eval/Eval.java
@@ -1,0 +1,118 @@
+package io.anserini.eval;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionHandlerFilter;
+import org.kohsuke.args4j.ParserProperties;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Searcher for Gov2, ClueWeb09, and ClueWeb12 corpra.
+ * TREC Web Tracks from 2009 to 2014
+ * TREC Terabyte Tracks from 2004 to 2006
+ */
+public final class Eval {
+
+  private static final Logger LOG = LogManager.getLogger(Eval.class);
+
+  public static String[] defaultMetrics = new String[] {
+    "num_ret", "num_rel", "num_rel_ret", "map",
+    "p.5", "p.10", "p.20", "p.30",
+  };
+
+  private static String[] allMetrics;
+  private static String[] allQueries;
+
+  static class EvalBundle {
+    public String format;
+    public Map<String, Double> evals;
+    public double aggregated;
+
+    EvalBundle(String format, Map<String, Double> evals, double aggregated) {
+      this.format = format;
+      this.evals = evals;
+      this.aggregated = aggregated;
+    }
+  }
+
+  private static Map<String, EvalBundle> allEvals;
+
+  public static void print(boolean printPerQuery, PrintStream output) {
+    String format = "%1$-22s\t%2$s\t%3$";
+    if (printPerQuery) {
+      String anyMetric = allMetrics[0];
+      Set<String> querySet = allEvals.get(anyMetric).evals.keySet();
+      String[] queries = querySet.toArray(new String[querySet.size()]);
+      for (String query : queries) {
+        for (String metric : allMetrics) {
+          String formattedOutput = format + allEvals.get(metric).format + "\n";
+          output.format(formattedOutput, metric, query, allEvals.get(metric).evals.get(query));
+        }
+      }
+    }
+    for (String metric : allMetrics) {
+      String formattedOutput = format + allEvals.get(metric).format + "\n";
+      output.format(formattedOutput, metric, "all", allEvals.get(metric).aggregated);
+    }
+  }
+
+  public static void eval(String runFile, String qrelFile) throws IOException {
+    RankingResults rr = new RankingResults(runFile);
+    QueryJudgments qj = new QueryJudgments(qrelFile);
+    allEvals = new TreeMap<>();
+    for (String metric : allMetrics) {
+      BatchEval bm = new BatchEval(metric);
+      Map<String, Double> evals = bm.evaluate(rr, qj);
+      double aggregated = bm.getAggregated();
+      String format = bm.getFormat();
+      allEvals.put(metric, new EvalBundle(format, evals, aggregated));
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    EvalArgs evalArgs = new EvalArgs();
+    CmdLineParser parser = new CmdLineParser(evalArgs, ParserProperties.defaults().withUsageWidth(90));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: Eval " + parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    allMetrics = evalArgs.reqMetrics == null ? defaultMetrics : evalArgs.reqMetrics;
+    if (allMetrics.length == 0) {
+      System.err.println("No metric provided...exit");
+      return;
+    }
+    eval(evalArgs.runPath, evalArgs.qrelPath);
+    print(evalArgs.printPerQuery, System.out);
+  }
+}

--- a/src/main/java/io/anserini/eval/Eval.java
+++ b/src/main/java/io/anserini/eval/Eval.java
@@ -31,9 +31,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 /**
- * Searcher for Gov2, ClueWeb09, and ClueWeb12 corpra.
- * TREC Web Tracks from 2009 to 2014
- * TREC Terabyte Tracks from 2004 to 2006
+ * Eval App
  */
 public final class Eval {
 
@@ -42,6 +40,7 @@ public final class Eval {
   public static String[] defaultMetrics = new String[] {
     "num_ret", "num_rel", "num_rel_ret", "map",
     "p.5", "p.10", "p.20", "p.30",
+    "ndcg.10", "ndcg.20"
   };
 
   private static String[] allMetrics;

--- a/src/main/java/io/anserini/eval/EvalArgs.java
+++ b/src/main/java/io/anserini/eval/EvalArgs.java
@@ -15,7 +15,10 @@ public class EvalArgs {
 
   // optional arguments
   @Option(name = "-m", handler = StringArrayOptionHandler.class, usage = "The metric to be printed. Valid ones are: "
-          +"[num_ret|num_rel|num_rel_ret|map|p[.cutoff]|ndcg[.cutoff]]")
+          +"[num_ret|num_rel|num_rel_ret|map|p[.cutoff]|ndcg[.cutoff]]. "
+          +"Several metrics can be printed at once - use space to separate them. "
+          +"Use \".\" to indicate the cutoff parameter for p (precision), ndcg. "
+          +" For example, -m map p.30 ndcg.20")
   String[] reqMetrics;
 
   @Option(name = "-q", handler = BooleanOptionHandler.class, usage = "Print the internal document IDs of documents")

--- a/src/main/java/io/anserini/eval/EvalArgs.java
+++ b/src/main/java/io/anserini/eval/EvalArgs.java
@@ -1,0 +1,23 @@
+package io.anserini.eval;
+
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.BooleanOptionHandler;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+public class EvalArgs {
+
+  // required arguments
+  @Option(name = "-run", metaVar = "[path]", required = true, usage = "The TREC formatted result file")
+  public String runPath;
+
+  @Option(name = "-qrels", metaVar = "[file]", required = true, usage = "Path to the qrels file")
+  public String qrelPath;
+
+  // optional arguments
+  @Option(name = "-m", handler = StringArrayOptionHandler.class, usage = "The metric to be printed. Valid ones are: "
+          +"[num_ret|num_rel|num_rel_ret|map|p[.cutoff]|ndcg[.cutoff]]")
+  String[] reqMetrics;
+
+  @Option(name = "-q", handler = BooleanOptionHandler.class, usage = "Print the internal document IDs of documents")
+  boolean printPerQuery;
+}

--- a/src/main/java/io/anserini/eval/QueryJudgments.java
+++ b/src/main/java/io/anserini/eval/QueryJudgments.java
@@ -1,0 +1,141 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval;
+
+import java.io.*;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * The judgments for a specific query.
+ * Relevance is represented by an integer:
+ * rel > 0  graded relevance
+ * rel == 0 non-relevant
+ * rel < 0  not judged (possibly categorized as non-relevant)
+ */
+public class QueryJudgments {
+  final private Map<String, Map<String, Integer>> qrels;
+
+  public QueryJudgments(String filename) throws IOException {
+    qrels = readJudgmentsFile(filename, false, false);
+  }
+
+  public Map<String, Map<String, Integer>> getQrels() {
+    return qrels;
+  }
+
+  public QueryJudgments(String filename, boolean graded, boolean ignoreNegative) throws IOException {
+    qrels = readJudgmentsFile(filename, graded, ignoreNegative);
+  }
+
+  /*
+  * read TREC formatted judgment file
+  * format: qnum  0   doc-name   grade
+  * e.g.
+  *  19    0   doc303       1
+   * 19    0   doc7295      0
+  */
+  public Map<String, Map<String, Integer>> readJudgmentsFile(String fileName, boolean graded, boolean ignoreNegative) throws IOException {
+    Map<String, Map<String, Integer>> judgments = new TreeMap<>();
+
+    InputStream stream;
+    if (fileName.endsWith(".gz")) { //.gz
+      stream = new DataInputStream(new GZIPInputStream(new FileInputStream(fileName)));
+    } else { // in case user had already uncompressed the folder
+      stream = new DataInputStream(new FileInputStream(fileName));
+    }
+
+    int lineNumber = 1;
+    try (BufferedReader in = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
+      while(true) {
+        String line = in.readLine();
+        if (line == null) {
+          break;
+        }
+
+        String[] arr = line.split("[\\s\\t]+");
+        if(arr.length != 4) {
+          throw new RuntimeException("Malformed line at line "+lineNumber+" in "+fileName+": "+ line);
+        }
+
+        String qid = arr[0];
+        String docno = arr[2];
+
+        if (!judgments.containsKey(qid)) {
+          judgments.put(qid, new TreeMap<>());
+        }
+
+        // add this judgment to the query
+        int grade =  Integer.parseInt(arr[3]);
+        if (grade < 0 && ignoreNegative) continue;
+        if (!graded) {
+          grade = (grade > 0) ? 1 : 0;
+        }
+        judgments.get(qid).put(docno, grade);
+        lineNumber++;
+      }
+    }
+    return judgments;
+  }
+
+  /**
+   * Method will return whether this docId for this qid is judged or not
+   * Note that if qid is invalid this will always return false
+   * @param qid     qid
+   * @param docId   docId
+   * @return
+   */
+  public boolean isDocJudged(String qid, String docId) {
+    if (!qrels.containsKey(qid)) {
+      return false;
+    }
+
+    if (!qrels.get(qid).containsKey(docId)) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  public int getRelevanceGrade(String qid, String docid) {
+    if (!qrels.containsKey(qid)) {
+      return 0;
+    }
+
+    if (!qrels.get(qid).containsKey(docid)) {
+      return 0;
+    }
+
+    if ( qrels.get(qid).get(docid) <= 0 ) return 0;
+    return qrels.get(qid).get(docid);
+  }
+
+  public Set<String> getQids() {
+    return this.qrels.keySet();
+  }
+
+  public Map<String, Integer> getDocMap(String qid) {
+    if (this.qrels.containsKey(qid)) {
+      return this.qrels.get(qid);
+    } else {
+      return null;
+    }
+  }
+}
+

--- a/src/main/java/io/anserini/eval/QueryJudgments.java
+++ b/src/main/java/io/anserini/eval/QueryJudgments.java
@@ -33,7 +33,7 @@ public class QueryJudgments {
   final private Map<String, Map<String, Integer>> qrels;
 
   public QueryJudgments(String filename) throws IOException {
-    qrels = readJudgmentsFile(filename, false, false);
+    qrels = readJudgmentsFile(filename, true, false);
   }
 
   public Map<String, Map<String, Integer>> getQrels() {

--- a/src/main/java/io/anserini/eval/RankingResults.java
+++ b/src/main/java/io/anserini/eval/RankingResults.java
@@ -1,0 +1,84 @@
+package io.anserini.eval;
+
+import java.io.*;
+import java.util.*;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * The ranking lists for some queries
+ */
+public class RankingResults {
+
+  final private Map<String, List<ResultDoc>> rankingList;
+
+  public RankingResults(Map<String, List<ResultDoc>> results) {
+    rankingList = new TreeMap<>();
+    for (String query : results.keySet()) {
+      ArrayList<ResultDoc> rankedList = new ArrayList<>(results.get(query));
+      Collections.sort(rankedList);
+      rankingList.put(query, rankedList);
+    }
+
+  }
+
+  public RankingResults(String filename) throws IOException {
+    rankingList = readResultsFile(filename);
+  }
+
+  public Map<String, List<ResultDoc>> getRankingList() {
+    return rankingList;
+  }
+
+  /**
+   * Reads in a TREC ranking file.
+   *
+   * format: qid Q0 docid rank score run_id
+   * 1 Q0 doc1 1 8.965 run_tag_1
+   * 1 Q0 doc2 2 7.465 run_tag_2
+   *
+   */
+  public Map<String, List<ResultDoc>> readResultsFile(String fileName) throws IOException {
+    TreeMap<String, List<ResultDoc>> ranking = new TreeMap<>();
+    InputStream stream;
+    if (fileName.endsWith(".gz")) { //.gz
+      stream = new DataInputStream(new GZIPInputStream(new FileInputStream(fileName)));
+    } else { // in case user had already uncompressed the folder
+      stream = new DataInputStream(new FileInputStream(fileName));
+    }
+
+    int lineNumber = 1;
+    try (BufferedReader in = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
+
+      while(true) {
+        String line = in.readLine();
+        if (line == null) {
+          break;
+        }
+
+        String[] arr = line.split("[\\s\\t]+");
+        if(arr.length < 6) {
+          throw new RuntimeException("Malformed line at line "+lineNumber+" in "+fileName+": "+ line);
+        }
+
+        String qid = arr[0];
+        String docno = arr[2];
+        //String rank = arr[3];
+        String score = arr[4];
+
+        ResultDoc document = new ResultDoc(docno, Double.parseDouble(score));
+        if (!ranking.containsKey(qid)) {
+          ranking.put(qid, new ArrayList<ResultDoc>());
+        }
+        ranking.get(qid).add(document);
+      }
+
+      // ensure sorted order by rank
+      for (String query : ranking.keySet()) {
+        List<ResultDoc> documents = ranking.get(query);
+        Collections.sort(documents);
+      }
+    }
+
+    return ranking;
+  }
+}

--- a/src/main/java/io/anserini/eval/ResultDoc.java
+++ b/src/main/java/io/anserini/eval/ResultDoc.java
@@ -1,0 +1,55 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval;
+
+/**
+ * single document in the ranking results
+ */
+public class ResultDoc implements Comparable<ResultDoc> {
+  protected double score;
+  protected String docid;
+
+  public ResultDoc(String docid, double score) {
+    this.docid = docid;
+    this.score = score;
+  }
+
+  public ResultDoc(ResultDoc resultDoc) {
+    this(resultDoc.getDocid(), resultDoc.getScore());
+  }
+
+  public double getScore() {
+    return score;
+  }
+
+  public String getDocid() {
+    return docid;
+  }
+
+  @Override
+  public int compareTo(ResultDoc r) {
+    Double thisScore = new Double(this.score);
+    Double otherScore = new Double(r.getScore());
+
+    // first compare the score then compare the docid
+    // We sort it REVERSELLY!!!
+    if (thisScore.equals(otherScore)) {
+      return r.getDocid().compareTo(this.docid);
+    }
+    return otherScore.compareTo(thisScore);
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/AvgPrecision.java
+++ b/src/main/java/io/anserini/eval/metric/AvgPrecision.java
@@ -1,0 +1,59 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Average Precision
+ */
+public class AvgPrecision extends MetricBase {
+  @Override
+  public String getName() {
+    return "ap";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    // first check whether there are at least one rel doc in the judgments
+    int num_rel = (int)new RelCount().evaluate(resultList, judgments);
+    if (num_rel == 0) {
+      return 0.0;
+    }
+
+    double res = 0.0;
+    int totalRelCount = 0;
+
+    for (int i = 0; i < resultList.size(); i++) {
+      ResultDoc doc = resultList.get(i);
+      String docid = doc.getDocid();
+      if (judgments.containsKey(docid) && (judgments.get(docid) > 0)) {
+        totalRelCount++;
+        res += (double)totalRelCount / (i+1);
+      }
+    }
+    return res / num_rel;
+  }
+
+  @Override
+  public String getFormat() {
+    return ".4f";
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/MetricBase.java
+++ b/src/main/java/io/anserini/eval/metric/MetricBase.java
@@ -1,0 +1,45 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The abstract class for all metrics.
+ * This applies to a single query.
+ */
+public abstract class MetricBase {
+  public MetricBase() {}
+
+  /*
+  * get the metric name
+  */
+  public abstract String getName();
+  /*
+  *
+  * evaluate a single query
+  */
+  public abstract double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments);
+
+  /*
+  * the format of print string
+  */
+  public abstract String getFormat();
+}

--- a/src/main/java/io/anserini/eval/metric/MetricFactory.java
+++ b/src/main/java/io/anserini/eval/metric/MetricFactory.java
@@ -34,11 +34,15 @@ public class MetricFactory {
         return new AvgPrecision();
     }
 
-    if(lower.startsWith("p")) {
+    if(lower.startsWith("p") || lower.startsWith("ndcg") ) {
+      int cutoff = Integer.MAX_VALUE;
       if (lower.contains(".")) {
-        return new Precision(Integer.parseInt(lower.substring(2)));
-      } else {
-        return new Precision();
+        cutoff = Integer.parseInt(lower.split("\\.")[1]);
+      }
+      if (lower.startsWith("p")) {
+        return new Precision(cutoff);
+      } else if (lower.startsWith("ndcg")) {
+        return new NDCG(cutoff);
       }
     }
 

--- a/src/main/java/io/anserini/eval/metric/MetricFactory.java
+++ b/src/main/java/io/anserini/eval/metric/MetricFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+
+public class MetricFactory {
+
+  public static MetricBase instance(String metric) {
+    String lower = metric.toLowerCase();
+    switch (lower) {
+      case "num_ret":
+        return new RetCount();
+      case "num_rel":
+        return new RelCount();
+      case "num_rel_ret":
+        return new RelRetCount();
+      case "map":
+      case "ap":
+        return new AvgPrecision();
+    }
+
+    if(lower.startsWith("p")) {
+      if (lower.contains(".")) {
+        return new Precision(Integer.parseInt(lower.substring(2)));
+      } else {
+        return new Precision();
+      }
+    }
+
+    throw new RuntimeException("Metric " + metric + " is not a valid metric.");
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/NDCG.java
+++ b/src/main/java/io/anserini/eval/metric/NDCG.java
@@ -1,0 +1,98 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Precision of a query, possibly with cutoff parameter
+ */
+public class NDCG extends MetricBase {
+  protected int cutoff;
+
+  public NDCG() {
+    super();
+    this.cutoff = Integer.MAX_VALUE;
+  }
+
+  public NDCG(int cutoff) {
+    super();
+    this.cutoff = cutoff;
+  }
+
+  @Override
+  public String getName() {
+    return "nDCG";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    Integer[] relList = new Integer[resultList.size()];
+    Arrays.fill(relList, 0);
+    // construct the rel list
+    int index = 0;
+    for (ResultDoc doc : resultList) {
+      String docid = doc.getDocid();
+      if (judgments.containsKey(docid) && judgments.get(docid) > 0) {
+        relList[index] = judgments.get(doc.getDocid());
+      }
+      index++;
+    }
+
+    double dcg = computeDCG(relList);
+
+    Integer[] idealList = new Integer[judgments.size()];
+    Arrays.fill(idealList, 0);
+    index = 0;
+    for (int judgment : judgments.values()) {
+      if (judgment > 0) {
+        idealList[index] = judgment;
+        index++;
+      }
+    }
+    Arrays.sort(idealList, Collections.reverseOrder());
+    double normalizer = computeDCG(idealList);
+
+    if(normalizer != 0){
+      return dcg / normalizer;
+    }
+
+    return 0.0;
+  }
+
+  /*
+  * Based on https://github.com/lintool/Anserini/blob/master/eval/gdeval.pl#L182
+  *  (2^rels[i]-1)/log2(i+1)
+  */
+  private double computeDCG(Integer[] rels) {
+    double dcg = 0.0;
+    for (int i = 0; i < Math.min(rels.length, this.cutoff); i++) {
+      dcg += (Math.pow(2, rels[i]) - 1.0) / (Math.log(i + 2)/Math.log(2.0));
+    }
+    return dcg;
+  }
+
+  @Override
+  public String getFormat() {
+    return ".4f";
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/Precision.java
+++ b/src/main/java/io/anserini/eval/metric/Precision.java
@@ -1,0 +1,66 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Precision of a query, possibly with cutoff parameter
+ */
+public class Precision extends MetricBase {
+  protected int cutoff;
+
+  public Precision() {
+    super();
+    cutoff = Integer.MAX_VALUE;
+  }
+
+  public Precision(int cutoff) {
+    super();
+    this.cutoff = cutoff;
+  }
+
+  @Override
+  public String getName() {
+    return "P";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    double retCnt = (resultList.size() < cutoff) ? resultList.size() : cutoff;
+    if(retCnt == 0){
+      return 0;
+    }
+    double res = 0;
+    for (int i = 0; i < retCnt; i++) {
+      ResultDoc doc = resultList.get(i);
+      String docid = doc.getDocid();
+      if (judgments.containsKey(docid) && (judgments.get(docid) > 0)) {
+        res++;
+      }
+    }
+    return res/retCnt;
+  }
+
+  @Override
+  public String getFormat() {
+    return ".4f";
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/RelCount.java
+++ b/src/main/java/io/anserini/eval/metric/RelCount.java
@@ -1,0 +1,48 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * get the total number of relevant docs for a query
+ */
+public class RelCount extends MetricBase {
+  @Override
+  public String getName() {
+    return "num_rel";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    int res = 0;
+    for (int grade : judgments.values()) {
+      if (grade > 0) {
+        res++;
+      }
+    }
+    return res;
+  }
+
+  @Override
+  public String getFormat() {
+    return ".0f";
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/RelRetCount.java
+++ b/src/main/java/io/anserini/eval/metric/RelRetCount.java
@@ -1,0 +1,50 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * get the number of relevant docs that are retrieved for a query
+ */
+public class RelRetCount extends MetricBase {
+  @Override
+  public String getName() {
+    return "num_rel_ret";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    int res = 0;
+    for (int i = 0; i < resultList.size(); i++) {
+      ResultDoc doc = resultList.get(i);
+      String docid = doc.getDocid();
+      if (judgments.containsKey(docid) && (judgments.get(docid) > 0)) {
+        res++;
+      }
+    }
+    return res;
+  }
+
+  @Override
+  public String getFormat() {
+    return ".0f";
+  }
+}

--- a/src/main/java/io/anserini/eval/metric/RetCount.java
+++ b/src/main/java/io/anserini/eval/metric/RetCount.java
@@ -1,0 +1,42 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval.metric;
+
+import io.anserini.eval.ResultDoc;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * get the total number of retrieved docs for a query
+ */
+public class RetCount extends MetricBase {
+  @Override
+  public String getName() {
+    return "num_ret";
+  }
+
+  @Override
+  public double evaluate(List<ResultDoc> resultList, Map<String, Integer> judgments) {
+    return resultList.size();
+  }
+
+  @Override
+  public String getFormat() {
+    return ".0f";
+  }
+}

--- a/src/test/java/io/anserini/eval/MetricsTest.java
+++ b/src/test/java/io/anserini/eval/MetricsTest.java
@@ -18,6 +18,7 @@ package io.anserini.eval;
 
 
 import io.anserini.eval.metric.AvgPrecision;
+import io.anserini.eval.metric.NDCG;
 import io.anserini.eval.metric.Precision;
 import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class MetricsTest extends LuceneTestCase {
   protected Map<String, Integer> judgments1;
   protected Map<String, Integer> judgments2;
 
-  protected static final double DELTA = 1e-8;
+  protected static final double DELTA = 1e-6;
 
   /**
    * MUST call super
@@ -59,7 +60,7 @@ public class MetricsTest extends LuceneTestCase {
     // construct the judgments
     judgments1 = new TreeMap<>();
     judgments1.put("d2", 1);
-    judgments1.put("d4", 1);
+    judgments1.put("d4", 3);
 
     // this is empty judgments
     judgments2 = new TreeMap<>();
@@ -83,5 +84,16 @@ public class MetricsTest extends LuceneTestCase {
 
     assertEquals(0.41666666666666, ap1, DELTA);
     assertEquals(0.0, ap2, DELTA);
+  }
+
+  @Test
+  public void testNDCG() throws IOException {
+    double ndcg1 = new NDCG().evaluate(rankingList, judgments1);
+    double ndcg2 = new NDCG(3).evaluate(rankingList, judgments1);
+    double ndcg3 = new NDCG().evaluate(rankingList, judgments2);
+
+    assertEquals(0.46059078, ndcg1, DELTA);
+    assertEquals(0.0655228, ndcg2, DELTA);
+    assertEquals(0.0, ndcg3, DELTA);
   }
 }

--- a/src/test/java/io/anserini/eval/MetricsTest.java
+++ b/src/test/java/io/anserini/eval/MetricsTest.java
@@ -1,0 +1,87 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval;
+
+
+import io.anserini.eval.metric.AvgPrecision;
+import io.anserini.eval.metric.Precision;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+public class MetricsTest extends LuceneTestCase {
+  protected List<ResultDoc> rankingList;
+  protected Map<String, Integer> judgments1;
+  protected Map<String, Integer> judgments2;
+
+  protected static final double DELTA = 1e-8;
+
+  /**
+   * MUST call super
+   * constructs the necessary rerankers and extractorchains
+   * @throws Exception
+   */
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    // construct ranking list
+    // d2 and d3 ties with score
+    ResultDoc d1 = new ResultDoc("d1", 2.02);
+    ResultDoc d2 = new ResultDoc("d2", 1.9998);
+    ResultDoc d3 = new ResultDoc("d3", 1.9998);
+    ResultDoc d4 = new ResultDoc("d4", 1.576);
+
+    rankingList = new ArrayList<>();
+    rankingList.add(d1);
+    rankingList.add(d2);
+    rankingList.add(d3);
+    rankingList.add(d4);
+    Collections.sort(rankingList);
+
+    // construct the judgments
+    judgments1 = new TreeMap<>();
+    judgments1.put("d2", 1);
+    judgments1.put("d4", 1);
+
+    // this is empty judgments
+    judgments2 = new TreeMap<>();
+  }
+
+  @Test
+  public void testPrecision() throws IOException {
+    double p1 = new Precision().evaluate(rankingList, judgments1);
+    double p2 = new Precision(3).evaluate(rankingList, judgments1);
+    double p3 = new Precision().evaluate(rankingList, judgments2);
+
+    assertEquals(0.5, p1, DELTA);
+    assertEquals(0.33333333, p2, DELTA);
+    assertEquals(0.0, p3, DELTA);
+  }
+
+  @Test
+  public void testAP() throws IOException {
+    double ap1 = new AvgPrecision().evaluate(rankingList, judgments1);
+    double ap2 = new AvgPrecision().evaluate(rankingList, judgments2);
+
+    assertEquals(0.41666666666666, ap1, DELTA);
+    assertEquals(0.0, ap2, DELTA);
+  }
+}

--- a/src/test/java/io/anserini/eval/RankingResultsTest.java
+++ b/src/test/java/io/anserini/eval/RankingResultsTest.java
@@ -1,0 +1,51 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.eval;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class RankingResultsTest {
+  @Test
+  public void testSorting() throws IOException {
+    // d2 and d3 ties with score
+    ResultDoc d1 = new ResultDoc("d1", 2.02);
+    ResultDoc d2 = new ResultDoc("d2", 1.9998);
+    ResultDoc d3 = new ResultDoc("d3", 1.9998);
+    ResultDoc d4 = new ResultDoc("d4", 1.576);
+
+    List<ResultDoc> l = new ArrayList<>();
+    l.add(d1);
+    l.add(d2);
+    l.add(d3);
+    l.add(d4);
+    Collections.sort(l);
+    String[] sorted = new String[4];
+    for (int i = 0; i < l.size(); i++) {
+      sorted[i] = l.get(i).getDocid();
+    }
+
+    String[] expected = {"d1", "d3", "d2", "d4"};
+
+    assertArrayEquals(expected, sorted);
+  }
+}


### PR DESCRIPTION
- add the `eval` module which evaluates the ranking list based on judgments.
- for now `map`, `precision`, `ndcg` are available.
- deal with ties the same way as `trec_eval`: first based on score then based on docno, both in descending order.
- got _exactly_ the same results with `trec_eval`, even for the padding format...see below the `diff`
- got the same results with `gdeval.pl` (`gdeval` prefers `.5f` print format while I use `.4f`)
![image](https://cloud.githubusercontent.com/assets/3334391/21081453/4022086c-bf95-11e6-95c3-d69addcdfe91.png)
![image](https://cloud.githubusercontent.com/assets/3334391/21081454/50ce1e6c-bf95-11e6-8337-7a66cbce1040.png)
![image](https://cloud.githubusercontent.com/assets/3334391/21087441/cd3bc07c-bff3-11e6-8e47-8ff0a868ce0a.png)

