### PR TITLE
Separate options to store raw docs and to store transformed docs

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -113,7 +113,7 @@ public final class IndexCollection {
     LOG.info("Keep stopwords: " + args.keepstop);
     LOG.info("Positions: " + args.positions);
     LOG.info("Store docvectors: " + args.docvectors);
-    LOG.info("Store docs: " + args.storedocs);
+    LOG.info("Store docs: " + args.storeTransformedDocs);
     LOG.info("Optimize (merge segments): " + args.optimize);
 
     this.indexPath = Paths.get(args.index);

--- a/src/main/java/io/anserini/index/IndexCollectionArgs.java
+++ b/src/main/java/io/anserini/index/IndexCollectionArgs.java
@@ -54,8 +54,11 @@ public class IndexCollectionArgs {
   @Option(name = "-docvectors", usage = "boolean switch to store document vectors")
   public boolean docvectors = false;
 
-  @Option(name = "-storedocs", usage = "boolean switch to store raw documen text")
-  public boolean storedocs = false;
+  @Option(name = "-storeTransformedDocs", usage = "boolean switch to store transformed document text")
+  public boolean storeTransformedDocs = false;
+
+  @Option(name = "-storeRawDocs", usage = "boolean switch to store raw document text")
+  public boolean storeRawDocs = false;
 
   @Option(name = "-optimize", usage = "boolean switch to optimize index (force merge)")
   public boolean optimize = false;

--- a/src/main/java/io/anserini/index/generator/JsoupGenerator.java
+++ b/src/main/java/io/anserini/index/generator/JsoupGenerator.java
@@ -50,9 +50,13 @@ public class JsoupGenerator extends LuceneDocumentGenerator<SourceDocument> {
     // document id
     document.add(new StringField(FIELD_ID, id, Field.Store.YES));
 
+    if (args.storeRawDocs) {
+      document.add(new StringField(FIELD_RAW, src.content(), Field.Store.YES));
+    }
+
     FieldType fieldType = new FieldType();
 
-    fieldType.setStored(args.storedocs);
+    fieldType.setStored(args.storeTransformedDocs);
 
     // Are we storing document vectors?
     if (args.docvectors) {

--- a/src/main/java/io/anserini/index/generator/JsoupGenerator.java
+++ b/src/main/java/io/anserini/index/generator/JsoupGenerator.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexOptions;
 import org.jsoup.Jsoup;
@@ -51,7 +52,7 @@ public class JsoupGenerator extends LuceneDocumentGenerator<SourceDocument> {
     document.add(new StringField(FIELD_ID, id, Field.Store.YES));
 
     if (args.storeRawDocs) {
-      document.add(new StringField(FIELD_RAW, src.content(), Field.Store.YES));
+      document.add(new StoredField(FIELD_RAW, src.content()));
     }
 
     FieldType fieldType = new FieldType();

--- a/src/main/java/io/anserini/index/generator/LuceneDocumentGenerator.java
+++ b/src/main/java/io/anserini/index/generator/LuceneDocumentGenerator.java
@@ -6,6 +6,7 @@ import io.anserini.index.IndexCollectionArgs;
 import org.apache.lucene.document.Document;
 
 public abstract class LuceneDocumentGenerator<T extends SourceDocument> {
+  public static final String FIELD_RAW = "raw";
   public static final String FIELD_BODY = "contents";
   public static final String FIELD_ID = "id";
 


### PR DESCRIPTION
-storeTransformedDocs: store transformed document text (e.g., HTML cleaning)
-storeRawDocs: store raw document text
